### PR TITLE
Fix path to make_munki_mpkg_DEP.sh

### DIFF
--- a/_posts/2017-03-08-Custom DEP Part 2 Creating a custom package and deploying Munki.md
+++ b/_posts/2017-03-08-Custom DEP Part 2 Creating a custom package and deploying Munki.md
@@ -109,7 +109,7 @@ If you are reading this, I am going to make a few assumptions:
 - `cd ./munki`
 
 5. Run the new [make_munki_mpkg_DEP](https://github.com/munki/munki/blob/master/code/tools/make_munki_mpkg_DEP.sh) script with the `-s` flag. You will pass your developer certificate as a string. This requires elevated permissions to run.
-  - `sudo ./munki/code/tools/make_munki_mpkg_DEP.sh -s "Developer ID Installer: Example (R9UM25C6B5)"`
+  - `sudo ./code/tools/make_munki_mpkg_DEP.sh -s "Developer ID Installer: Example (R9UM25C6B5)"`
 
 If everything goes right you should see the following in Terminal:
 


### PR DESCRIPTION
Since you've already `cd`'d into `~/DEP/munki/` (in 'CREATING THE PACKAGE' - Step 4), the following command should read:
`sudo ./code/tools/make_munki_mpkg_DEP.sh -s "Developer ID Installer: Example (R9UM25C6B5)"`
...instead of...
`sudo ./munki/code/tools/make_munki_mpkg_DEP.sh -s "Developer ID Installer: Example (R9UM25C6B5)"`