### PR TITLE
Added Note to Clarify Profile Assignment Type

### DIFF
--- a/_posts/2019-10-31-CMDM Part 2 managing workspace one profiles with chef using the new v1910 hubcli agent.md
+++ b/_posts/2019-10-31-CMDM Part 2 managing workspace one profiles with chef using the new v1910 hubcli agent.md
@@ -101,7 +101,7 @@ Examples:
         hubcli profiles --list --json
 ```
 
-If we run `hubcli profiles --list --json` we get nice json list of all profiles currently scoped to the device.
+If we run `hubcli profiles --list --json` we get a nice json list of all the profiles currently scoped to the device. If a profile isn't listed, confirm the `Assignment Type` is set to `Optional` and the profile is scoped to the Mac.
 ```
 {
   "DeviceProfiles" : [


### PR DESCRIPTION
In addition to proper profile scoping, `Assignment Type` must be set to `Optional` otherwise `hubcli profiles --list --json` won't see it.

Thank you for this post!